### PR TITLE
Update user endpoint to get instagram feed

### DIFF
--- a/ig.php
+++ b/ig.php
@@ -6,7 +6,7 @@ require_once('cache.php');
 class InstagramOAuth extends Cache {
 
 	public function get_feed($label, $userid, $accessToken){
-			return parent::get_the_json($label, 'https://api.instagram.com/v1/users/'.$userid.'/media/recent/?access_token='.$accessToken.'&count=20');
+			return parent::get_the_json($label, 'https://api.instagram.com/v1/users/self/media/recent/?access_token='.$accessToken.'&count=20');
 	}
 
 }


### PR DESCRIPTION
Delivers:

[[Sexton - Implement ACF for IG images]](https://app.asana.com/0/513333057245101/937533873950073) --> the name of this ticket is obsolete, please read comments in ticket for clarification.